### PR TITLE
Kubernetes volumes

### DIFF
--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+  labels:
+    app.kubernetes.io/name: staticweb
+data:
+  nginx.conf: |
+    events {
+        worker_connections 1024;
+    }
+    http {
+      access_log /dev/stdout;
+      error_log /dev/stdout info;
+      server {
+          listen       8000;
+          server_name  _;
+          root   /homework;
+          index  index.html;
+      }
+    }

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -77,6 +77,5 @@ spec:
             - key: "nginx.conf"
               path: "nginx.conf"
       - name: shared
-        emptyDir:
-          medium: ""
-          sizeLimit: 1Mi
+        persistentVolumeClaim:
+          claimName: "pvc001"

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+  labels:
+    app.kubernetes.io/name: staticweb
+data:
+  nginx.conf: |
+    events {
+        worker_connections 1024;
+    }
+    http {
+      access_log /dev/stdout;
+      error_log /dev/stdout info;
+      server {
+          listen       8000;
+          server_name  _;
+          root   /homework;
+          index  index.html;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staticweb-deployment
+  namespace: homework
+  labels:
+    app.kubernetes.io/name: staticweb
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: staticweb
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 2
+  template:
+    metadata:
+      name: staticweb
+      namespace: homework
+      labels:
+        app.kubernetes.io/name: staticweb
+    spec:
+      nodeSelector:
+        homework: "true"
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - name: staticweb-port
+          containerPort: 8000
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","rm -rf /homework/index.html"]
+        volumeMounts:
+        - name: nginx-main-conf
+          mountPath: /etc/nginx
+          readOnly: true
+        - name: shared
+          mountPath: /homework
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: staticweb-port
+            httpHeaders:
+            - name: X-Readiness-Probe
+              value: k8s-local
+          initialDelaySeconds: 10
+          periodSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: staticweb-port
+            httpHeaders:
+            - name: K8SHealthChecker
+              value: LivenessProbe
+          initialDelaySeconds: 5
+          periodSeconds: 3
+      initContainers:
+      - name: htmlgenerator
+        image: alpine:latest
+        args:
+          - /bin/sh
+          - -c
+          - echo "i am index.html" > /init/index.html
+        volumeMounts:
+        - name: shared
+          mountPath: "/init"
+      volumes:
+      - name: nginx-main-conf
+        configMap:
+          name: nginx-config
+          items:
+            - key: "nginx.conf"
+              path: "nginx.conf"
+      - name: shared
+        emptyDir:
+          medium: ""
+          sizeLimit: 1Mi

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,27 +1,4 @@
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: nginx-config
-  namespace: homework
-  labels:
-    app.kubernetes.io/name: staticweb
-data:
-  nginx.conf: |
-    events {
-        worker_connections 1024;
-    }
-    http {
-      access_log /dev/stdout;
-      error_log /dev/stdout info;
-      server {
-          listen       8000;
-          server_name  _;
-          root   /homework;
-          index  index.html;
-      }
-    }
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes-volumes/ingress.yaml
+++ b/kubernetes-volumes/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homework3
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($uri ~* "^/homepage$") {
+        rewrite /homepage /index.html last;
+      }
+spec:
+  ingressClassName: nginx
+  defaultBackend:
+    service:
+      name: staticweb
+      port:
+        number: 8000
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: staticweb
+            port:
+              number: 8000

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+  labels:
+    name: homework

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/no-provisioner
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv001
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 100Mi
+  claimRef:
+    name: pvc001
+    namespace: homework
+  local:
+    path: /srv/
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: homework
+          operator: In
+          values:
+          - 'true'
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: "local-storage"
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc001
+  namespace: homework
+spec:
+  storageClassName: "local-storage"
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 10Mi

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staticweb
+  namespace: homework
+  labels:
+    app.kubernetes.io/name: staticweb
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: staticweb
+  ports:
+  - name: static-web-svc-port
+    protocol: TCP
+    port: 8000
+    targetPort: staticweb-port
+


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [x] Основное ДЗ
 - [x] Задание со * (так как нет миникуба то сделано с имитацией - pv с классом local-storage создан заране, так как  local-storage provisioner не работает: `Local volumes do not support dynamic provisioning in Kubernetes 1.30; ` )

## В процессе сделано:
 - Изменены параметры запуска kube-api для поддержки DefaultStorageClass "--enable-admission-plugins=NodeRestriction,DefaultStorageClass"
 - Добавлен локальный StorageClass "local-storage" помечен как "default"
 - deployment.yaml обновлён для использования pvc в качестве volume'a
 - ConfigMap вынесен в отдельный файл

## Как запустить проект:
 - kubectl label node/<nodename> homework=true
 - kubectl apply -f namespace.yaml -f cm.yaml -f pvc.yaml -f deployment.yaml -f service.yaml -f ingress.yaml

## Как проверить работоспособность:
 - curl -H "Host: homework.otus" http://<ingress-ip>
 - curl -i -H "Host: homework.otus" http://<ingress-ip>/homepage
 - curl -i -H "Host: homework.otus" http://<ingress-ip>/someotherpage

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
